### PR TITLE
fix jest and git hook for ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "stylelint-config-standard": "^18.2.0",
     "stylelint-declaration-use-variable": "^1.6.1",
     "stylelint-scss": "^3.2.0",
-    "ts-jest": "^23.1.4",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-react": "^3.6.0",
@@ -61,6 +60,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx}": "eslint",
+    "src/**/*.{ts,tsx}": "tslint",
     "src/**/*.scss": "stylelint"
   },
   "engines": {
@@ -70,7 +70,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",
-      "!src/registerServiceWorker.js"
+      "!src/registerServiceWorker.ts"
     ]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -3,5 +3,8 @@
     "member-access": [true, "no-public"],
     "ordered-imports": false
   },
-  "extends": ["tslint-react", "tslint:recommended", "tslint-config-prettier"]
+  "extends": ["tslint-react", "tslint:recommended", "tslint-config-prettier"],
+  "linterOptions": {
+    "exclude": ["node_modules/**/*.ts", "coverage/lcov-report/*.js"]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1719,10 +1719,6 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
-closest-file-data@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/closest-file-data/-/closest-file-data-0.1.4.tgz#975f87c132f299d24a0375b9f63ca3fb88f72b3a"
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -3375,14 +3371,6 @@ fs-extra@3.0.1:
 fs-extra@4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -8604,15 +8592,6 @@ ts-jest@22.0.1:
     pkg-dir "^2.0.0"
     source-map-support "^0.5.0"
     yargs "^10.0.3"
-
-ts-jest@^23.1.4:
-  version "23.1.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.1.4.tgz#66ac1d8d3fbf8f9a98432b11aa377aa850664b2b"
-  dependencies:
-    closest-file-data "^0.1.4"
-    fs-extra "6.0.1"
-    json5 "^0.5.0"
-    lodash "^4.17.10"
 
 ts-loader@^2.3.7:
   version "2.3.7"


### PR DESCRIPTION
Problem
=======
- `yarn test` wasn't working
- `lint-staged wasn't checking ts files.

Solution
========
- Remove `ts-jest`, as create-react-app uses an earlier version of that dependency
- Add .ts files to package.json

Steps to Verify:
----------------
1. `yarn test`
