### PR TITLE
Updates link to be Spraygun-React so they don't get out of sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ npx spraygun -t react-ts <project-directory>
 
 If you'd like to use spraygun-react-ts with a Rails API backend, follow this guide:
 
-> [Using spraygun-react with a Rails backend](./docs/how-to-use-with-rails-backend.md)
+> [Using spraygun-react with a Rails backend](https://github.com/carbonfive/spraygun-react/blob/master/docs/how-to-use-with-rails-backend.md)
 
 _Below this line is the README that will accompany your generated project._
 


### PR DESCRIPTION
Problem
=======
Updated Spraygun-React Readme and wanted to make sure Spraygun-React-TS stays in sync.

Solution
========
Updated Readme to link to the Spraygun-React app.

Change summary:
---------------
* Updated Readme