### PR TITLE
Use proper typescript version of eslint no-unused-vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "jest", "prettier"],
   "rules": {
-    "no-unused-vars": [
+    "@typescript-eslint/no-unused-vars": [
       "error",
       {
         "args": "after-used",


### PR DESCRIPTION
# Problem + Solution

The default `no-unused-vars` eslint rule doesn't work reliably with typescript. According to the `@typescript-eslint/eslint-plugin` [FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/9f7ec660daeccb47a55d552243b1fcfb183183a1/docs/getting-started/linting/FAQ.md#i-am-using-a-rule-from-eslint-core-and-it-doesnt-work-correctly-with-typescript-code), we are supposed to use the typescript-specific one.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/README.md#extension-rules
