### PR TITLE
Disable dependabot for now (switching to Depfu)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,5 @@ updates:
       day: wednesday
       time: "14:00"
       timezone: America/Los_Angeles
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
We're going to try using Depfu for managing dependency updates on this repo. So for now am disabling dependabot.