### PR TITLE
Enable recommended jsx-a11y lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,12 @@
 module.exports = {
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint", "jest", "prettier", "testing-library"],
+  plugins: [
+    "@typescript-eslint",
+    "jest",
+    "jsx-a11y",
+    "prettier",
+    "testing-library",
+  ],
   rules: {
     "@typescript-eslint/no-unused-vars": [
       "error",
@@ -20,6 +26,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:jest/recommended",
+    "plugin:jsx-a11y/recommended",
     "plugin:testing-library/react",
     "prettier",
   ],


### PR DESCRIPTION
Problem
=======

The `react-app` eslint presets do not enable all of the `jsx-a11y` rules that we care about.

Solution
========

Enable the recommended set of a11y lint rules by extending `plugin:jsx-a11y/recommended`.

Steps to Verify:
----------------
1. Edit `Counter.tsx` to change `<button>` to `<div>`.
2. Run `yarn lint`.
3. You should see an error from the a11y linter.

```
/Users/mattb/Code/carbonfive/spraygun-react-ts/src/components/Counter.tsx
  10:7  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
  10:7  error  Static HTML elements with event handlers require a role                                         jsx-a11y/no-static-element-interactions

✖ 2 problems (2 errors, 0 warnings)
```
