### PR TITLE
Switch from BEM to CSS modules

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,7 +1,5 @@
 module.exports = {
-  plugins: [
-    "stylelint-declaration-strict-value"
-  ],
+  plugins: ["stylelint-declaration-strict-value"],
   extends: ["stylelint-config-standard", "stylelint-config-recommended-scss"],
   rules: {
     "declaration-empty-line-before": null,
@@ -41,22 +39,6 @@ module.exports = {
     ],
     "scss/no-duplicate-dollar-variables": true,
     "scss/selector-no-redundant-nesting-selector": true,
-    "selector-class-pattern": [
-      // Classes must be in BEM form, like this:
-      //   MyComponent
-      //   MyComponent--variant
-      //   MyComponent__element
-      //   MyComponent__element--variant
-      //   MyComponent__longElementName
-      //   MyComponent__longElementName--longVariant
-      // For an introduction, see: https://css-tricks.com/bem-101/
-      "^[A-Z][a-zA-Z0-9]+(__[a-z][a-zA-Z0-9]+)?(--[a-z][a-zA-Z0-9]+)*$",
-      {
-        resolveNestedSelectors: true,
-        message:
-          "CSS classes should use BEM format like MyComponent__element--variant",
-      },
-    ],
     "selector-max-compound-selectors": 1,
     "selector-max-id": 0,
     "selector-no-qualifying-type": true,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a Carbon Five-flavored convenience skeleton project for React. It is based on create-react-app (not ejected) with the following additions:
 
-- Styling via .scss with BEM conventions
+- Styling via SCSS modules
 - Stylelint
 - ESLint/Prettier
 - Husky with lint-staged

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -1,11 +1,11 @@
 @use "theme/colors.scss";
 @use "theme/typography.scss";
 
-.App {
+.container {
   text-align: center;
 }
 
-.App__logo {
+.logo {
   height: 40vmin;
   pointer-events: none;
 
@@ -14,7 +14,7 @@
   }
 }
 
-.App__header {
+.header {
   @include typography.headline-text;
 
   background-color: colors.$gray-28;
@@ -26,11 +26,11 @@
   color: colors.$white;
 }
 
-.App__code {
+.code {
   font-family: typography.$font-monospace;
 }
 
-.App__link {
+.link {
   color: colors.$blue;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,19 @@
 import logo from "./logo.svg";
-import "./App.scss";
+import styles from "./App.module.scss";
 import Counter from "components/Counter";
 
 const App = (): JSX.Element => {
   return (
-    <div className="App">
-      <header className="App__header">
+    <div className={styles.container}>
+      <header className={styles.header}>
         <Counter />
-        <img src={logo} className="App__logo" alt="logo" />
+        <img src={logo} className={styles.logo} alt="logo" />
         <p>
-          Edit <code className="App__code">src/App.tsx</code> and save to
+          Edit <code className={styles.code}>src/App.tsx</code> and save to
           reload.
         </p>
         <a
-          className="App__link"
+          className={styles.link}
           href="https://reactjs.org"
           target="_blank"
           rel="noopener noreferrer"

--- a/src/components/Counter.module.scss
+++ b/src/components/Counter.module.scss
@@ -1,11 +1,11 @@
 @use "theme/colors.scss";
 @use "theme/typography.scss";
 
-.Counter {
+.container {
   @include typography.body-text;
 }
 
-.Counter__button {
+.button {
   @include typography.body-text;
 
   align-items: center;

--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from "react";
-import "./Counter.scss";
+import styles from "./Counter.module.scss";
 
 const Counter = (): JSX.Element => {
   const [count, setCount] = useState(0);
 
   return (
-    <div className="Counter">
+    <div className={styles.container}>
       An example stateful component.
-      <button className="Counter__button" onClick={() => setCount(count + 1)}>
+      <button className={styles.button} onClick={() => setCount(count + 1)}>
         {count}
       </button>
     </div>


### PR DESCRIPTION
Problem
=======

BEM is great, but in a React project we have CSS modules at our disposal, which solves the same problems as BEM (i.e. namespacing) but in a more robust way. BEM has a couple drawbacks:

1. It's a small thing, but BEM requires adhering to a strict set of naming conventions, and that can rub people the wrong way. These conventions are arbitrary and look weird (double-underscores).
2. On larger teams or on larger codebases, it is easy to accidentally create two different BEM class names that collide. For example, two different engineers might both be building new pages and have their own `Header` component. Even though those components are in two completely different sections of the file tree, they get compiled down to the same class name in the global namespace. These collisions might not be noticed by the team until strange bugs and visual regressions appear down the road.

Solution
========

Change our default recommendation to use CSS modules with SCSS syntax. This brings the familiarity of CSS with the namespace safety of JS modules.

Now, each `.module.scss` file effectively has its own private namespace, and so it can't conflict with the CSS of any other component.

Steps to Verify:
----------------
1. Run the app with `yarn start`.
2. Verify the app renders as expected.
3. Verify hot reloading of SCSS changes still works.

Screenshots (optional):
-----------------------

![Screen Shot 2021-10-29 at 2 06 27 PM](https://user-images.githubusercontent.com/189693/139501696-35aefaf8-c8ce-4121-84c5-0471077ae7c4.png)
