### PR TITLE
Update Rails recommendations; remove Redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,13 @@ This is a Carbon Five-flavored convenience skeleton project for React. It is bas
 - Deployable to Heroku out of the box
 - Or deploy via docker using the included Dockerfile
 
-To get started, make sure you have Node 10+ and Yarn installed, and then generate your project like this:
+To get started, make sure you have Node 16 and Yarn installed, and then generate your project like this:
 
 ```
 $ npx spraygun -t react-ts <project-directory>
 ```
 
-If you'd like to use spraygun-react-ts with a Rails API backend, follow this guide:
-
-> [Using spraygun-react with a Rails backend](https://github.com/carbonfive/spraygun-react/blob/main/docs/how-to-use-with-rails-backend.md)
-
-If you'd like to use spraygun-react-ts with Redux, here are potential file structures:
-
-> [Redux file structures](https://github.com/carbonfive/spraygun-react/blob/main/docs/example-redux-file-structure.md)
+💡 If you'd like to use spraygun-react-ts with with Rails, start by generating a Rails project with [raygun](https://github.com/carbonfive/raygun), and follow the [instructions for enabling React with TypeScript](https://github.com/carbonfive/raygun#react-with-typescript) in Rails. From there, you can cherry-pick files and patterns from this template into your React frontend in `app/javascript/`.
 
 _Below this line is the README that will accompany your generated project._
 


### PR DESCRIPTION
Problem
======

The README for this project had fallen behind our latest best practices at Carbon Five.

Solution
======

Rails has a good, reliable integration with React via webpacker. It comes with Rails out of the box, and has the benefit of convention over configuration.

This commit updates our official recommendation for Rails+React to use the built-in webpacker approach. I've link to the documentation for this that already exists in the raygun README.

Next, this commit removes our Redux recommendations from the README. Redux may still have its place on some projects, but I believe it shouldn't be something that we reach for right away. The goal of spraygun is to get people started with something quickly for a greenfield app. There are simpler ways to manage state in React that work great on small code bases and don't have the Redux learning curve.

Finally, update the instructions to require Node 16.
