### PR TITLE
Adopt latest Carbon Five PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,49 @@
 Problem
 =======
+
 problem statement, including
 [link to Pivotal Tracker #12345678](https://www.pivotaltracker.com/story/show/12345678)
 
 Solution
 ========
+
 What I/we did to solve this problem
 
 with @pairperson1
 
-Change summary:
----------------
+Change summary
+--------------
+
 * Tidy, well formulated commit message
 * Another great commit message
 * Something else I/we did
 
-Steps to Verify:
-----------------
+Steps to Verify
+---------------
+
 1. A setup step / beginning state
 1. What to do next
 1. Any other instructions
 1. Expected behavior
 1. Suggestions for testing
 
-Screenshots (optional):
------------------------
-Show-n-tell images/animations here
+<!-- delete the following section if this PR adds no new dependencies -->
 
+New Dependencies
+----------------
+
+Consider adding links to relevant listings from https://snyk.io/advisor/
+
+<!-- delete the following sections if this PR has no UI changes -->
+
+Accessibility Checks
+--------------------
+
+- [ ] Text remains visible and feature is still functional even when browser is zoomed 200%
+- [ ] Feature is functional using purely keyboard-based interactions
+- [ ] Passes a Lighthouse audit (choose Lighthouse tab in Google Chrome devtools and run reports with **accessibility** selected, for both desktop and mobile)
+
+Screenshots
+-----------
+
+Show-n-tell images/animations here


### PR DESCRIPTION
This commit updates our PR template to use the latest version from the Carbon Five raygun-rails repo.

It makes the following changes of note:

1. I added a dependencies section. When a new dependency is added to a project, this is worth calling out. In my experience it is worth using a site like snyk to gauge the health of a library. The PR template is a good place to link to those health assessments.
2. Creating accessible apps is part of what we do as good software engineers, but it is helpful to be reminded so that accessibility bugs don't slip through the cracks. I've added a short checklist of things that are easy to test.

More information here:
https://github.com/carbonfive/raygun-rails/pull/626
